### PR TITLE
Add Redis Integration for Caching Chat Sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.3"
+services:
+  redis:
+    image: redis/redis-stack-server:latest
+    container_name: redis
+    restart: always
+    volumes:
+      - redis_volume_data:/data
+    ports:
+      - 6379:6379
+  redis_insight:
+    image: redislabs/redisinsight:1.14.0
+    container_name: redis_insight
+    restart: always
+    ports:
+      - 8001:8001
+    volumes:
+      - redis_insight_volume_data:/db
+
+volumes:
+  redis_volume_data:
+  redis_insight_volume_data:

--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -1,0 +1,4 @@
+from .redis_client import redis_client
+from .chat_cache import CachingFunc
+
+__all__ = ["redis_client", "CachingFunc"]

--- a/src/cache/chat_cache.py
+++ b/src/cache/chat_cache.py
@@ -1,0 +1,68 @@
+import logging
+import json
+import ast
+from typing import List
+from src.cache.redis_client import redis_client
+
+# Logging config
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Constants
+MAX_HISTORY_LENGTH = 50
+SESSION_TTL_SECONDS = 60 * 60 * 12  # 12 hours
+
+class CachingFunc:
+    #role must be user or assistant
+    @staticmethod
+    def save_chat(user_id: str, role: str, message: str):
+        try:
+            if role not in ("user", "assistant"):
+                raise ValueError("Invalid role. Must be 'user' or 'assistant'.")
+            entry = {"role": role, "message": message}
+            key = f"chat:{user_id}"
+            redis_client.rpush(key, json.dumps(entry))
+            redis_client.ltrim(key, -MAX_HISTORY_LENGTH, -1)
+            redis_client.expire(key, SESSION_TTL_SECONDS)
+        except Exception as e:
+            logger.error(f"Error saving chat for user_id={user_id}: {e}")
+
+    @staticmethod
+    def get_chat_history(user_id: str) -> str:
+        try:
+            key = f"chat:{user_id}"
+            raw_history = redis_client.lrange(key, 0, -1)
+            history = [ast.literal_eval(entry) for entry in raw_history]
+            return json.dumps(history, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.error(f"Error getting chat history for user_id={user_id}: {e}")
+            return "[]"
+
+    @staticmethod
+    def delete_session_chats(user_id: str):
+        try:
+            redis_client.delete(f"chat:{user_id}")
+        except Exception as e:
+            logger.error(f"Error deleting chat history for user_id={user_id}: {e}")
+
+
+
+"""
+def main():
+    user_id = "tytyty"
+    #CachingFunc.save_chat(user_id, "user", "Hello AI!")
+    #CachingFunc.save_chat(user_id, "assistant", "Hi there! How can I help you today?")
+
+    chat = CachingFunc.get_chat_history(user_id)
+    print(chat)
+
+    CachingFunc.delete_session_chats(user_id)
+
+if __name__ == "__main__":
+    main()
+
+    
+"""

--- a/src/cache/redis_client.py
+++ b/src/cache/redis_client.py
@@ -1,0 +1,23 @@
+# Connection to redis #
+import redis
+import os
+
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
+REDIS_DB = int(os.getenv("REDIS_DB", 0))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", None)  
+
+redis_client = redis.Redis(
+    host=REDIS_HOST,
+    port=REDIS_PORT,
+    db=REDIS_DB,
+    password=REDIS_PASSWORD,
+    decode_responses=True  
+)
+
+try:
+    redis_client.ping()
+    print(f"Connected to Redis!")
+except redis.exceptions.ConnectionError as e:
+    print(f"Redis connection error: {e}")
+


### PR DESCRIPTION
docker-compose.yml: Added configuration to run a Redis server locally using Docker.
redis_client.py: Initializes and exports a Redis client instance for use across modules.
chat_cache.py: Implements the CachingFunc class with methods to:
        Save chat messages (save_chat)
        Retrieve full session history (get_chat_history)
        Delete session data (delete_session_chats)