### PR TITLE
Add in logic to save ai responses for chat history

### DIFF
--- a/frontend/onc-ai-assistant/src/app/chatPage/ChatHistoryManager.tsx
+++ b/frontend/onc-ai-assistant/src/app/chatPage/ChatHistoryManager.tsx
@@ -64,7 +64,7 @@ export default function ChatHistoryManager({ children }: ChatHistoryManagerProps
     title: apiChat.summary || "New Chat",
     messages: messages.map(msg => ({
       id: msg.id,
-      sender: msg.user_id === userId ? "user" : "ai",
+      sender: msg.user_id === "-1" ? "ai" : (msg.user_id === userId ? "user" : "ai"), // -1 = AI, matching userId = user, other = ai
       text: msg.text,
       chat_id: msg.chat_id,
       user_id: msg.user_id,
@@ -168,7 +168,7 @@ export default function ChatHistoryManager({ children }: ChatHistoryManagerProps
                 ...chat,
                 messages: apiMessages.map(msg => ({
                   id: msg.id,
-                  sender: msg.user_id === userId ? "user" : "ai",
+                  sender: msg.user_id === "-1" ? "ai" : (msg.user_id === userId ? "user" : "ai"), // -1 = AI, matching userId = user, other = ai
                   text: msg.text,
                   chat_id: msg.chat_id,
                   user_id: msg.user_id,


### PR DESCRIPTION
Previously AI responses were not saved to back end so if you tried to log out and log back in, the AI responses would be gone. this PR will fix that issue by pushing AI responses to the back end with a user id of -1. When the chat history receives a response with user id of -1 it knows to format the message as an AI response.